### PR TITLE
Set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - "6.9"
+
+branches:
+  only:
+    - master
+
+before_script:
+  - npm install -g @angular/cli
+
+script:
+  - ng test --single-run
+  - ng e2e
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ branches:
   only:
     - master
 
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3
+
 before_script:
   - npm install -g @angular/cli
 


### PR DESCRIPTION
Set up Travis CI for running tests (both `ng test` and `ng e2e`). [Sample build here](https://travis-ci.org/sheharyarn/spotify-roulette/builds/291223505). Resolves #10. 